### PR TITLE
Fix fatal config error and switch to upstream otel-collector-contrib

### DIFF
--- a/configs/otel-collector.yaml
+++ b/configs/otel-collector.yaml
@@ -10,9 +10,9 @@
 receivers:
   otlp/1:
     protocols:
-      grpc/1:
+      grpc:
         endpoint: "0.0.0.0:55680"
-      http/1:
+      http:
         endpoint: "0.0.0.0:55681"
 
 # TODO: tag all events to make it clear it's localdev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
   # to receive on popular supported protocols and forward to Tempo.
   # TODO: open up all the popular protocols for ingest
   otel-collector:
-    image: public.ecr.aws/aws-observability/aws-otel-collector:latest
+    image: otel/opentelemetry-collector-contrib
     ports:
       # TODO: double-check my knowledge and write descriptive comments for ports
-      - 55680:55680 # OTLP 
+      - 55680:55680 # OTLP
       - 55681:55681 # OTLP
       - 6831:6831/udp # Jaeger
     volumes:


### PR DESCRIPTION
There is a bug in the configuration: `'protocols' has invalid keys: grpc/1, http/1`
This PR corrects that bug. It also does something a little more drastic,
because it switches to the upstream OTel collector-contrib rather than
the AWS distro of the collector.

Why? Well, primarily this: https://github.com/aws-observability/aws-otel-collector/issues/340
I was unable to launch the OTel collector after cloning the repo, and
that bug prevented the collector from giving me any useful output
whatsoever. As the bug reporter mentioned:

> This is a very frustrating experience util you switch to otelcol or otelcontribcol ....

Indeed, it is. So I also did just that: switched to the upstream
opentelemetry-collector-contrib. Once I switched images, the error was
immediately apparent.

Switching to the upstream collector isn't necessary to fix the config
error, but it does seem like that's where the development work happens
these days. Moreover, the receivers/exporters that the AWS repo lists as
unique to their distro ... don't seem to be unique to their distro at
all. They're all supported in the -contrib version of the collector
these days. Perhaps there's something else they provide that makes it
worth sticking with them, but I'm not sure what it is. Regardless, I am
happy to amend this PR to remove the collector-switch if that's preferable.
