### PR TITLE
Add local storage to loki/grafana/tempo

### DIFF
--- a/configs/loki.yaml
+++ b/configs/loki.yaml
@@ -29,15 +29,15 @@ schema_config:
 
 storage_config:
   boltdb_shipper:
-    active_index_directory: /tmp/loki/boltdb-shipper-active
-    cache_location: /tmp/loki/boltdb-shipper-cache
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
     shared_store: filesystem
   filesystem:
-    directory: /tmp/loki/chunks
+    directory: /loki/chunks
 
 compactor:
-  working_directory: /tmp/loki/boltdb-shipper-compactor
+  working_directory: /loki/boltdb-shipper-compactor
   shared_store: filesystem
 
 limits_config:
@@ -55,8 +55,8 @@ ruler:
   storage:
     type: local
     local:
-      directory: /tmp/loki/rules
-  rule_path: /tmp/loki/rules-temp
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
   alertmanager_url: http://localhost:9093
   ring:
     kvstore:

--- a/configs/tempo.yaml
+++ b/configs/tempo.yaml
@@ -10,7 +10,7 @@ distributor:
   # @tobert - thinking it makes sense to turn on all the things here too
   # so the internals of the stack can write directly to Tempo and not get
   # egressed to an external observability stack, that seems cool
-  receivers:                           
+  receivers:
     # gets used by the Jaeger UI so it's handy to have it on here
     jaeger:
       protocols:
@@ -38,9 +38,9 @@ storage:
   trace:
     backend: local                     # backend configuration to use
     wal:
-      path: /tmp/tempo/wal             # where to store the the wal locally
+      path: /var/tempo/wal             # where to store the the wal locally
     local:
-      path: /tmp/tempo/blocks
+      path: /var/tempo/blocks
     pool:
       max_workers: 100                 # the worker pool mainly drives querying, but is also used for polling the blocklist
       queue_depth: 10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - 55683:55683
     volumes:
       - ./configs/tempo.yaml:/config.yaml
+      - tempo-storage:/var/tempo
     command: -config.file=/config.yaml
 
   # Jaeger frontend for Grafana Tempo will be on http://$ip:16686
@@ -49,6 +50,7 @@ services:
       - "3100:3100"
     volumes:
       - ./configs/loki.yaml:/config.yaml
+      - loki-storage:/loki
     command: -config.file=/config.yaml
 
   # TODO: make this more useful for rando users out there in the world
@@ -66,8 +68,14 @@ services:
       - "0.0.0.0:3000:3000"
     volumes:
       - ./configs/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - grafana-storage:/var/lib/grafana
     environment:
       # TODO: document security implications in README
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
+
+volumes:
+  grafana-storage: {}
+  tempo-storage: {}
+  loki-storage: {}


### PR DESCRIPTION
I typically run grafana and friends with local docker volumes (or
occasionally bind-mount local directories) so that changes I make in
those services persist whenever my laptop crashes. :rofl:

This PR does the same thing:
- Creates three docker volumes
- Configures docker-compose to use them
- Alters loki and tempo configurations accordingly

The grafana image, by convention, uses /var/lib/grafana for local
storage so that's sufficient for setup there. Loki and Tempo both
require changes to their configs - I moved Tempo storage out of /tmp
(which felt odd for a persistent storage path to me). Loki's latest
docker config specifies /loki as the path, so I used that too (there are
actually multiple docker configs in the loki repo? One still uses /tmp,
but that config seems ... to not work for me).
